### PR TITLE
Split workflow in two jobs for deploy approval

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -16,12 +16,13 @@ on:
 env:
   AZURE_RESOURCE_GROUP: rg-todo-sample  # target resource, must match the {resource-group-name} you setup in the pre-requisties
   WEB_APP_NAME: app-todo-sample         # set the name for the Web App on Azure
-  ACR_NAME: acrtodosample               # set the name for the Azure Container Registry
   CONTAINER_IMAGE_NAME: app-todo-sample # set the name for the container image
   SQL_SERVER_NAME: sql-todo-sample      # set the name for the Azure SQL Server
-  SQL_SERVER_ADMIN_LOGIN: dbadminlogin  # set the name for the Azure SQL Server admin login
-  SQL_SERVER_ADMIN_PASSWORD: ${{ secrets.SQL_SERVER_ADMIN_PASSWORD }}  # password for the Azure SQL Sever admin login -> must be in the secrets
-  SQL_DB_NAME: sqldb-todo               # set the name for the Azure SQL Database
+  SQL_CONNECTION_STRING: ${{ secrets.SQL_CONNECTION_STRING }}  # connection string for the Azure SQL database -> must be in the secrets
+  ACR_NAME: acrtodosample               # set the name for the Azure Container Registry
+  ACR_LOGIN_SERVER: ${{ env.ACR_NAME }}.azurecr.io # fqdn for the Azure Container Registry
+  ACR_USERNAME: ${{ secrets.ACR_USERNAME }} # user name for accessing Azure Container Registry
+  ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }} # password for accesing the Azure Container Registry
 
 jobs:
   build:
@@ -34,21 +35,6 @@ jobs:
       uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-    - name: Get ACR Info
-      run: |
-        # Retrieve information from Azure
-        LOGIN_SERVER=$(az acr show --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.ACR_NAME }} --query loginServer -o tsv)
-        USERNAME=$(az acr show --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.ACR_NAME }} --query name -o tsv)
-        PASSWORD=$(az acr credential show --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.ACR_NAME }} --query passwords[0].value -o tsv)
-
-        # Ensure the password is masked when written to the logs
-        echo "::add-mask::$PASSWORD"
-        
-        # Export variables to the GitHub environment
-        echo "ACR_LOGIN_SERVER=$LOGIN_SERVER" >> $GITHUB_ENV 
-        echo "ACR_USERNAME=$USERNAME" >> $GITHUB_ENV
-        echo "ACR_PASSWORD=$PASSWORD" >> $GITHUB_ENV
 
     - name: Login to ACR
       uses: azure/docker-login@v1
@@ -90,32 +76,9 @@ jobs:
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-    - name: Get ACR Info & Database Connection
+    - name: Version Date for App Settings
       run: |
-        # Retrieve information from Azure
-        LOGIN_SERVER=$(az acr show --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.ACR_NAME }} --query loginServer -o tsv)
-        USERNAME=$(az acr show --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.ACR_NAME }} --query name -o tsv)
-        PASSWORD=$(az acr credential show --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.ACR_NAME }} --query passwords[0].value -o tsv)
-        CONN_STR=$(az sql db show-connection-string --client ado.net --server ${{ env.SQL_SERVER_NAME }} --name ${{ env.SQL_DB_NAME }} -o tsv)
-        CONN_STR=$(echo $CONN_STR | sed "s/<username>/${{ env.SQL_SERVER_ADMIN_LOGIN }}/g")
-        CONN_STR=$(echo $CONN_STR | sed "s/<password>/${{ env.SQL_SERVER_ADMIN_PASSWORD }}/g")
-
-        # Ensure the password is masked when written to the logs
-        echo "::add-mask::$PASSWORD"
-        
-        # Export variables to the GitHub environment
-        echo "ACR_LOGIN_SERVER=$LOGIN_SERVER" >> $GITHUB_ENV 
-        echo "ACR_USERNAME=$USERNAME" >> $GITHUB_ENV
-        echo "ACR_PASSWORD=$PASSWORD" >> $GITHUB_ENV
-        echo "SQL_DB_CONN_STR=$CONN_STR" >> $GITHUB_ENV
         echo "APP_VERSION_DATE=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
-
-    # - name: Login to ACR
-    #   uses: azure/docker-login@v1
-    #   with:
-    #     login-server: ${{ env.ACR_LOGIN_SERVER }}
-    #     username: ${{ env.ACR_USERNAME }}
-    #     password: ${{ env.ACR_PASSWORD }}
 
     - name: Set Web App Settings
       uses: Azure/appservice-settings@v1
@@ -124,26 +87,6 @@ jobs:
         slot-name: staging
         app-settings-json: |
           [
-            {
-              "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
-              "value": "false",
-              "slotSetting": false
-            },
-            {
-              "name": "DOCKER_REGISTRY_SERVER_URL",
-              "value": "${{ env.ACR_LOGIN_SERVER }}",
-              "slotSetting": false
-            },
-            {
-              "name": "DOCKER_REGISTRY_SERVER_USERNAME",
-              "value": "${{ env.ACR_USERNAME  }}",
-              "slotSetting": false
-            },
-            {
-              "name": "DOCKER_REGISTRY_SERVER_PASSWORD",
-              "value": "${{ env.ACR_PASSWORD }}",
-              "slotSetting": false
-            },
             {
               "name": "VersionInfo__Number",
               "value": "1.0.${{ github.run_number }}",
@@ -155,16 +98,7 @@ jobs:
               "slotSetting": false
             }
           ]
-        connection-strings-json: |
-          [
-            {
-              "name": "MyDbConnection",
-              "value": "${{ env.SQL_DB_CONN_STR }}",
-              "type": "SQLAzure",
-              "slotSetting": false
-            }
-          ]
-
+          
     - name: Deploy Azure WebApp to Staging
       uses: azure/webapps-deploy@v2
       with: 
@@ -185,7 +119,7 @@ jobs:
         dotnet ef database update
       env:
         ASPNETCORE_ENVIRONMENT: Development
-        ConnectionStrings__MyDbConnection: ${{ env.SQL_DB_CONN_STR }}
+        ConnectionStrings__MyDbConnection: ${{ env.SQL_CONNECTION_STRING }}
       working-directory: application
 
     - name: Swap to production slot

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -80,10 +80,11 @@ jobs:
   deploy:
     needs: [build]
     runs-on: ubuntu-latest
+    environment: test
     steps:
     - name: Checkout Source Code
       uses: actions/checkout@v2
-      
+
     - name: Login for az cli commands 
       uses: azure/login@v1
       with:

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -78,8 +78,12 @@ jobs:
       working-directory: application
 
   deploy:
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout Source Code
+      uses: actions/checkout@v2
+      
     - name: Login for az cli commands 
       uses: azure/login@v1
       with:

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -24,12 +24,63 @@ env:
   SQL_DB_NAME: sqldb-todo               # set the name for the Azure SQL Database
 
 jobs:
-  build_deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Source Code
       uses: actions/checkout@v2
 
+    - name: Login for az cli commands 
+      uses: azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: Get ACR Info
+      run: |
+        # Retrieve information from Azure
+        LOGIN_SERVER=$(az acr show --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.ACR_NAME }} --query loginServer -o tsv)
+        USERNAME=$(az acr show --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.ACR_NAME }} --query name -o tsv)
+        PASSWORD=$(az acr credential show --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.ACR_NAME }} --query passwords[0].value -o tsv)
+
+
+        # Ensure the password is masked when written to the logs
+        echo "::add-mask::$PASSWORD"
+        
+        # Export variables to the GitHub environment
+        echo "ACR_LOGIN_SERVER=$LOGIN_SERVER" >> $GITHUB_ENV 
+        echo "ACR_USERNAME=$USERNAME" >> $GITHUB_ENV
+        echo "ACR_PASSWORD=$PASSWORD" >> $GITHUB_ENV
+
+    - name: Login to ACR
+      uses: azure/docker-login@v1
+      with:
+        login-server: ${{ env.ACR_LOGIN_SERVER }}
+        username: ${{ env.ACR_USERNAME }}
+        password: ${{ env.ACR_PASSWORD }}
+    
+    - name: Build & Push Container
+      run: |
+        echo "Build image and push to ${{ env.ACR_LOGIN_SERVER }}"
+
+        echo "Building the container..."
+        docker build -t ${{ env.CONTAINER_IMAGE_NAME }}:ci .
+        echo
+
+        echo "Tagging for ACR..."
+        docker tag ${{ env.CONTAINER_IMAGE_NAME }}:ci ${{ env.ACR_LOGIN_SERVER }}/${{ env.CONTAINER_IMAGE_NAME }}:${{ github.sha }}
+        echo
+
+        echo "Push image to ACR"
+        docker push ${{ env.ACR_LOGIN_SERVER }}/${{ env.CONTAINER_IMAGE_NAME }}:${{ github.sha }}
+        echo
+
+        echo "List the repositories in the ACR"
+        az acr repository list -n ${{ env.ACR_LOGIN_SERVER }}        
+      working-directory: application
+
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
     - name: Login for az cli commands 
       uses: azure/login@v1
       with:
@@ -61,26 +112,6 @@ jobs:
         login-server: ${{ env.ACR_LOGIN_SERVER }}
         username: ${{ env.ACR_USERNAME }}
         password: ${{ env.ACR_PASSWORD }}
-    
-    - name: Build & Push Container
-      run: |
-        echo "Build image and push to ${{ env.ACR_LOGIN_SERVER }}"
-
-        echo "Building the container..."
-        docker build -t ${{ env.CONTAINER_IMAGE_NAME }}:ci .
-        echo
-
-        echo "Tagging for ACR..."
-        docker tag ${{ env.CONTAINER_IMAGE_NAME }}:ci ${{ env.ACR_LOGIN_SERVER }}/${{ env.CONTAINER_IMAGE_NAME }}:${{ github.sha }}
-        echo
-
-        echo "Push image to ACR"
-        docker push ${{ env.ACR_LOGIN_SERVER }}/${{ env.CONTAINER_IMAGE_NAME }}:${{ github.sha }}
-        echo
-
-        echo "List the repositories in the ACR"
-        az acr repository list -n ${{ env.ACR_LOGIN_SERVER }}        
-      working-directory: application
 
     - name: Set Web App Settings
       uses: Azure/appservice-settings@v1

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -42,7 +42,6 @@ jobs:
         USERNAME=$(az acr show --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.ACR_NAME }} --query name -o tsv)
         PASSWORD=$(az acr credential show --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.ACR_NAME }} --query passwords[0].value -o tsv)
 
-
         # Ensure the password is masked when written to the logs
         echo "::add-mask::$PASSWORD"
         
@@ -106,12 +105,12 @@ jobs:
         echo "SQL_DB_CONN_STR=$CONN_STR" >> $GITHUB_ENV
         echo "APP_VERSION_DATE=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
 
-    - name: Login to ACR
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ env.ACR_LOGIN_SERVER }}
-        username: ${{ env.ACR_USERNAME }}
-        password: ${{ env.ACR_PASSWORD }}
+    # - name: Login to ACR
+    #   uses: azure/docker-login@v1
+    #   with:
+    #     login-server: ${{ env.ACR_LOGIN_SERVER }}
+    #     username: ${{ env.ACR_USERNAME }}
+    #     password: ${{ env.ACR_PASSWORD }}
 
     - name: Set Web App Settings
       uses: Azure/appservice-settings@v1

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -87,6 +87,26 @@ jobs:
         app-settings-json: |
           [
             {
+              "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
+              "value": "false",
+              "slotSetting": false
+            },
+            {
+              "name": "DOCKER_REGISTRY_SERVER_URL",
+              "value": "${{ env.ACR_LOGIN_SERVER }}",
+              "slotSetting": false
+            },
+            {
+              "name": "DOCKER_REGISTRY_SERVER_USERNAME",
+              "value": "${{ env.ACR_USERNAME  }}",
+              "slotSetting": false
+            },
+            {
+              "name": "DOCKER_REGISTRY_SERVER_PASSWORD",
+              "value": "${{ env.ACR_PASSWORD }}",
+              "slotSetting": false
+            },
+            {
               "name": "VersionInfo__Number",
               "value": "1.0.${{ github.run_number }}",
               "slotSetting": false
@@ -94,6 +114,15 @@ jobs:
             {
               "name": "VersionInfo__Date",
               "value": "${{ env.APP_VERSION_DATE }}",
+              "slotSetting": false
+            }
+          ]
+        connection-strings-json: |
+          [
+            {
+              "name": "MyDbConnection",
+              "value": "${{ env.SQL_CONNECTION_STRING }}",
+              "type": "SQLAzure",
               "slotSetting": false
             }
           ]

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -19,7 +19,7 @@ env:
   CONTAINER_IMAGE_NAME: app-todo-sample # set the name for the container image
   SQL_CONNECTION_STRING: ${{ secrets.SQL_CONNECTION_STRING }}  # connection string for the Azure SQL database -> must be in the secrets
   ACR_NAME: acrtodosample               # set the name for the Azure Container Registry
-  ACR_LOGIN_SERVER: ${{ env.ACR_NAME }}.azurecr.io # fqdn for the Azure Container Registry
+  ACR_LOGIN_SERVER: acrtodosample.azurecr.io # fqdn for the Azure Container Registry
   ACR_USERNAME: ${{ secrets.ACR_USERNAME }} # user name for accessing Azure Container Registry
   ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }} # password for accesing the Azure Container Registry
 

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -17,7 +17,6 @@ env:
   AZURE_RESOURCE_GROUP: rg-todo-sample  # target resource, must match the {resource-group-name} you setup in the pre-requisties
   WEB_APP_NAME: app-todo-sample         # set the name for the Web App on Azure
   CONTAINER_IMAGE_NAME: app-todo-sample # set the name for the container image
-  SQL_SERVER_NAME: sql-todo-sample      # set the name for the Azure SQL Server
   SQL_CONNECTION_STRING: ${{ secrets.SQL_CONNECTION_STRING }}  # connection string for the Azure SQL database -> must be in the secrets
   ACR_NAME: acrtodosample               # set the name for the Azure Container Registry
   ACR_LOGIN_SERVER: ${{ env.ACR_NAME }}.azurecr.io # fqdn for the Azure Container Registry
@@ -76,7 +75,7 @@ jobs:
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-    - name: Version Date for App Settings
+    - name: Set version date
       run: |
         echo "APP_VERSION_DATE=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
 
@@ -98,7 +97,7 @@ jobs:
               "slotSetting": false
             }
           ]
-          
+
     - name: Deploy Azure WebApp to Staging
       uses: azure/webapps-deploy@v2
       with: 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,13 @@ Add the following secrets to your repo:
 - AZURE_CREDENTIALS: the content is the output of the previous executed command.
 - SQL_SERVER_ADMIN_PASSWORD: this will be the password used to setup and access the Azure SQL database.
 
+There are other additional secrets that you will need to add after the environment has been created in the next step.
+
 For further deatils, check https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository
 
 Finally, review both workflows and ensure the defined variables have the correct values and matches the pre-requisites you have just setup.
+
+
 
 ### 4. Execute the Create Resources workflow
  Go to your repo [Actions](../../actions) tab, under *All workflows* you will see the [Create Azure Resources](../../actions?query=workflow%3A"Create+Azure+Resources") workflow. 
@@ -92,6 +96,11 @@ Finally, review both workflows and ensure the defined variables have the correct
 Launch the workflow by using the *[workflow_dispatch](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)* event trigger.
 
 This will create all the required resources in the Azure Subscription and Resource Group you configured.
+
+Now add the following secrets to your repo (those will be used by the build_deploy workflow):
+- ACR_USERNAME: you can pick it from the Azure Container Registry settings, in the *Access Keys*.
+- ACR_PASSWORD: use one of the passwords from the Azure Container Registry settings, in the *Access Keys*.
+- SQL_CONNECTION_STRING: pick it from the SQL DB connection string settings. It has the following format: *Server=tcp:<SQL_SERVER_NAME>.database.windows.net,1433;Initial Catalog=sqldb-todo;Persist Security Info=False;User ID=<SQL_SERVER_ADMIN_LOGIN>;Password=<SQL_SERVER_ADMIN_PASSWORD>;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;*
 
 ## Test your CI/CD workflow
 To launch the CI/CD workflow (Build image, push & deploy), you just need to make a change in the app code. You will see a new GitHub action initiated in the [Actions](../../actions) tab.
@@ -115,16 +124,19 @@ To ilustrate the versioning, the workflow generates a version number, based in t
 
 To ilustrate the usage of [Environments](https://docs.github.com/en/actions/reference/environments) a *test* environment has been added to the repo and the *Required reviewers* protection rule has been configured to enable the approval or rejection of a certain deployment. For more information check [Reviewing deployments](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments).
 
-The definition is in the [build-deploy.yaml](.github/workflows/build-deploy.yaml) file, and have the following steps:
-* Check out the source code by using the [Checkout](https://github.com/actions/checkout) action.
-* Login to azure CLI to gather environment and azure resources information by using the [Azure Login](https://github.com/Azure/login) action.
-* Executes a custom in-line script to get the required resources information and secrets related to the Azure Container Registry and the Azure SQL Database.
-* Executes a custom script to build the web application container image and push it to the Azure Container Registry, giving a unique label.
-* Updates the Web App Settings with the latest required values by using the [Azure App Service Settings](https://github.com/Azure/appservice-settings) action.
-* Updates the App Service Web Application deployment for the *staging* slot by using the [Azure Web App Deploy](https://github.com/Azure/webapps-deploy) action.
-* Setup the .NET Core enviroment versio to the latest 3.1, by using the [Setup DotNet](https://github.com/actions/setup-dotnet) action.
-* Executes a custom script to update the SQL Database by using the dotnet entity framework tool.
-* Finally, executes an Azure CLI script to swap the *staging* slot to *production*
+The definition is in the [build-deploy.yaml](.github/workflows/build-deploy.yaml) file, and have two jobs with the following steps:
+* Job: build
+  * Check out the source code by using the [Checkout](https://github.com/actions/checkout) action.
+  * Login to azure CLI to gather environment and azure resources information by using the [Azure Login](https://github.com/Azure/login) action.
+  * Executes a custom script to build the web application container image and push it to the Azure Container Registry, giving a unique label.
+* Job: Deploy (using the environment *test* for explicit approval)
+  * Check out the source code by using the [Checkout](https://github.com/actions/checkout) action.
+  * Login to azure CLI to gather environment and azure resources information by using the [Azure Login](https://github.com/Azure/login) action.
+  * Updates the Web App Settings with the latest values by using the [Azure App Service Settings](https://github.com/Azure/appservice-settings) action.
+  * Updates the App Service Web Application deployment for the *staging* slot by using the [Azure Web App Deploy](https://github.com/Azure/webapps-deploy) action.
+  * Setup the .NET Core enviroment versio to the latest 3.1, by using the [Setup DotNet](https://github.com/actions/setup-dotnet) action.
+  * Executes a custom script to update the SQL Database by using the dotnet entity framework tool.
+  * Finally, executes an Azure CLI script to swap the *staging* slot to *production*
 
 ## Contributing
 Refer to the [Contributing page](/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The workflow is configured to be triggered by each change made to your repo sour
 The definition is in the [build-deploy.yaml](.github/workflows/build-deploy.yaml) file, and have the following steps:
 * Check out the source code by using the [Checkout](https://github.com/actions/checkout) action.
 * Login to azure CLI to gather environment and azure resources information by using the [Azure Login](https://github.com/Azure/login) action.
-* Executes a custom in-line script to get the required resources information related to the Azure Container Registry and the Azure SQL Database.
+* Executes a custom in-line script to get the required resources information and secrets related to the Azure Container Registry and the Azure SQL Database.
 * Executes a custom script to build the web application container image and push it to the Azure Container Registry, giving a unique label.
 * Updates the Web App Settings with the latest required values by using the [Azure App Service Settings](https://github.com/Azure/appservice-settings) action.
 * Updates the App Service Web Application deployment for the *staging* slot by using the [Azure Web App Deploy](https://github.com/Azure/webapps-deploy) action.

--- a/README.md
+++ b/README.md
@@ -109,9 +109,11 @@ Use this workflow to initially setup the Azure Resources by executing the ARM te
 ### Buid image, push, deploy
 This workflow builds the container with the latest web app changes, push it to the Azure Container Registry and, updates the web application *staging* slot to point to the latest container pushed. Then updates the database (just in case there is any change to be reflected in the database schema). Finally, swap the slots to leave the latest version in the production slot. 
 
+The workflow is configured to be triggered by each change made to your repo source code (excluding changes affecting to the *infrastructure* and *.github/workflows* folders). 
+
 To ilustrate the versioning, the workflow generates a version number, based in the [github workflow run number](https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#github-context) context variable, which is stored in the app service web application settings. 
 
-The workflow is configured to be triggered by each change made to your repo source code (excluding changes affecting to the *infrastructure* and *.github/workflows* folders). 
+To ilustrate the usage of [Environments](https://docs.github.com/en/actions/reference/environments) a *test* environment has been added to the repo and the *Required reviewers* protection rule has been configured to enable the approval or rejection of a certain deployment. For more information check [Reviewing deployments](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments).
 
 The definition is in the [build-deploy.yaml](.github/workflows/build-deploy.yaml) file, and have the following steps:
 * Check out the source code by using the [Checkout](https://github.com/actions/checkout) action.


### PR DESCRIPTION
## Purpose
Update the CI/CD workflow in two jobs, one for build & push the container and other for the actual deployment. Include an environment and require approval for the deployment job.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```
## Changes
* Added the "test" environment to the repo. Added "Required reviewers" control.
* The build_deploy workflow updated with two jobs.
* The deploy job targets the environment "test" so it require approval to be executed.
* Added more secrets to the repo to simplify the workflow (avoid gathering azure resources info and secrets dynamically, which is good but introduce more complexity in the workflow).
* Updated the read me accordingly. 

## Pull Request Type
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
N/A

## What to Check
N/A

## Other Information
Verified with existing azure environment and a azure clean environment.